### PR TITLE
Add `unidecode_fast` function to speed-up mostly-ascii transliteration.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -54,6 +54,17 @@ ASCII bytes in Python 3.x)::
     >>> unidecode(u"\u5317\u4EB0")
     'Bei Jing '
 
+For use cases where most strings passed are ASCII and only some occassional
+non-ASCII ones, use the `unidecode_fast` function::
+
+    >>> from unidecode import unidecode_fast
+    >>> unidecode_fast(u'Hello world!')
+    'Hello world!'
+
+This function about an order of magnitude faster if the string only contains
+ASCII characters, but sligthly slower than using `unidecode` directly when
+non-ASCII chars are present.
+
 A utility is also included that allows you to transliterate text from the
 command line in several ways. Reading from standard input::
 

--- a/tests/test_unidecode.py
+++ b/tests/test_unidecode.py
@@ -2,7 +2,7 @@
 # vim:ts=4 sw=4 expandtab softtabstop=4
 import unittest
 import sys
-from unidecode import unidecode
+from unidecode import unidecode, unidecode_fast
 import warnings
 
 # workaround for Python < 2.7
@@ -501,6 +501,17 @@ class TestUnidecode(unittest.TestCase):
             o = unidecode(s)
 
             self.assertEqual('THE QUICK BROWN FOX JUMPS OVER THE LAZY DOG 1234567890', o)
+
+
+class TestUnidecodeFast(unittest.TestCase):
+    def test_ascii_fast(self):
+        out = unidecode_fast(_u('Hello, World!'))
+        self.assertEqual(out, 'Hello, World!')
+
+    def test_nonascii_fast(self):
+        out = unidecode_fast(_u('příliš žluťoučký kůň pěl ďábelské ódy'))
+        self.assertEqual(out, 'prilis zlutoucky kun pel dabelske ody')
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
See https://github.com/avian2/unidecode/issues/2

This one uses `codecs` and `unidecode` as fallback function for non-ASCII chars, which is faster than the previous PR.