### PR TITLE
Fix the microfarad capitalization

### DIFF
--- a/unidecode/x033.py
+++ b/unidecode/x033.py
@@ -139,7 +139,7 @@ data = (
 'kcal',    # 0x89
 'pF',    # 0x8a
 'nF',    # 0x8b
-'microFarad',    # 0x8c
+'microfarad',    # 0x8c
 'microgram',    # 0x8d
 'mg',    # 0x8e
 'kg',    # 0x8f


### PR DESCRIPTION
It's spelled μF, and this is probably where the capital F came from. But as a word it's all lowercase, "microfarad".

Also maybe just use `uF` instead?