### PR TITLE
Greatly simplify tox configuration

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,18 +1,5 @@
 [tox]
-envlist =
-	py27-latest,py34-latest,py35-latest,py36-latest
+envlist = py{27,34,35,36}
 
 [testenv]
 commands = python setup.py test
-
-[testenv:py27-latest]
-basepython = python2.7
-
-[testenv:py34-latest]
-basepython = python3.4
-
-[testenv:py35-latest]
-basepython = python3.5
-
-[testenv:py36-latest]
-basepython = python3.6


### PR DESCRIPTION
The project requires a very simple tox file and so can remove a lot of boilerplate and re-specifying of tox defaults. When using py36 notation, the "basepython" configuration option has a correct default.