### PR TITLE
Update test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,12 @@
+dist: xenial
 language: python
 python:
-  - "pypy"
-  - "pypy3"
   - 2.7
   - 3.4
   - 3.5
   - 3.6
-  - 3.7-dev
+  - 3.7
+  - pypy2.7-6.0
+  - pypy3.5-6.0
 script:
   - python setup.py test

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,34,35,36}
+envlist = py{27,34,35,36,37,py,py3}
 
 [testenv]
 commands = python setup.py test


### PR DESCRIPTION
Test Python 3.7 and PyPy in tox.ini and Travis CI. Python 3.7 was released on 2018-06-27.

https://docs.python.org/3/whatsnew/3.7.html

Use 'dist: xenial' in Travis to allow using the latest Python 3.7. Travis officially added support for Xenial on 2018-11-08.

https://blog.travis-ci.com/2018-11-08-xenial-release