### PR TITLE
Use a context manager to always close the file after opening

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,8 @@ from setuptools import setup
 
 
 def get_long_description():
-    return open(os.path.join(os.path.dirname(__file__), "README.rst")).read()
+    with open(os.path.join(os.path.dirname(__file__), "README.rst")) as fp:
+        return fp.read()
 
 setup(
     name='Unidecode',


### PR DESCRIPTION
Fixes the following warning when Python warnings are enabled during tests:

```
    setup.py:9: ResourceWarning: unclosed file <_io.TextIOWrapper name='README.rst' mode='r' encoding='UTF-8'>
      return open(os.path.join(os.path.dirname(__file__), "README.rst")).read()
```

To enable warnings, use the pass the `-Walways` argument to Python:

https://docs.python.org/3/using/cmdline.html#cmdoption-w