### PR TITLE
Pass python_requires argument to setuptools

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -77,8 +77,8 @@ full list of available options.
 Requirements
 ------------
 
-Nothing except Python itself.
-    
+Nothing except Python itself. Unidecode supports Python 2.7 and 3.4+.
+
 You need a Python build with "wide" Unicode characters (also called "UCS-4
 build") in order for unidecode to work correctly with characters outside of
 Basic Multilingual Plane (BMP). Common characters outside BMP are bold, italic,

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ setup(
     author_email='tomaz.solc@tablix.org',
 
     packages=['unidecode'],
+    python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*",
 
     test_suite='tests',
 


### PR DESCRIPTION
Helps pip decide what version of the library to install. Include this information in the README as well. These versions were already documented as trove classifiers.

https://packaging.python.org/guides/distributing-packages-using-setuptools/#python-requires

> If your project only runs on certain Python versions, setting the python_requires argument to the appropriate PEP 440 version specifier string will prevent pip from installing the project on other Python versions.

https://setuptools.readthedocs.io/en/latest/setuptools.html#new-and-changed-setup-keywords

> python_requires
>
> A string corresponding to a version specifier (as defined in PEP 440) for the Python version, used to specify the Requires-Python defined in PEP 345.