### PR TITLE
Add __main__.py file so the CLI can be executed as a module

### DIFF
--- a/unidecode/__main__.py
+++ b/unidecode/__main__.py
@@ -1,0 +1,3 @@
+from unidecode.util import main
+
+main()


### PR DESCRIPTION
Allows running the following command to execute the CLI

     $ python -m unidecode ...

https://docs.python.org/3/library/__main__.html

> For a package, the same effect can be achieved by including a
> __main__.py module, the contents of which will be executed when the
> module is run with -m.