### PR TITLE
add GitHub URL for PyPi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,9 @@ setup(
     long_description=get_long_description(),
     author='Tomaz Solc',
     author_email='tomaz.solc@tablix.org',
+    project_urls={
+        'Source': 'https://github.com/avian2/unidecode',
+    },
 
     packages=['unidecode'],
     package_data={'unidecode': ['py.typed']},


### PR DESCRIPTION
Warehouse now uses the project_urls provided to display links in the sidebar on [this screen](https://pypi.org/project/requests/), as well as including them in API responses to help the automation tool find the source code for Requests.

Example: [pypi.org/pypi/requests/json](https://pypi.org/pypi/requests/json)
Docs: [packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls](https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls)