### PR TITLE
Transliterate ‘ẞ’ as ‘SS’

### DIFF
--- a/unidecode/x01e.py
+++ b/unidecode/x01e.py
@@ -157,7 +157,7 @@ data = (
 'S',    # 0x9b
 None,    # 0x9c
 None,    # 0x9d
-'Ss',    # 0x9e
+'SS',    # 0x9e
 None,    # 0x9f
 'A',    # 0xa0
 'a',    # 0xa1


### PR DESCRIPTION
The German Eszett can either be lowercase (which should become ‘ss’) or
uppercase (which should become ‘SS’).  There exists no titlecase
variant for this letter just like with the Dutch ĳ/Ĳ ligatures.
