### PR TITLE
Fix usage of obsolete Chinese character in example (北京 instead of 北亰)

### DIFF
--- a/unidecode/__init__.py
+++ b/unidecode/__init__.py
@@ -5,7 +5,7 @@
 Example usage:
 
 >>> from unidecode import unidecode
->>> unidecode("\u5317\u4EB0")
+>>> unidecode("\u5317\u4EAC")
 "Bei Jing "
 
 The transliteration uses a straightforward map, and doesn't have alternatives


### PR DESCRIPTION
Hi there thanks for working on this package, I noticed the example used an obsolete Chinese character (I'm Chinese), just quickly fixed it here.

So AFAIK the capical of China should always be written as "北京" instead of "北亰"


[Reference](https://baike.baidu.com/item/%E4%BA%AC/70950?fr=aladdin):
> 受古文字体影响，一些书法作品中的“京”字中部多出一横，写作“亰”。现代规范写法的“京”字中部没有多出一横。 [2] [6] [16]

> Due to the influence of ancient script styles, some calligraphy works write the character ‘京’ with an extra horizontal stroke in the middle, as ‘亰’. In the modern standardized form, the character ‘京’ does not have this extra stroke

Also a quick answer from GPT-5:
<img width="964" height="316" alt="image" src="https://github.com/user-attachments/assets/0bc82ef5-e297-44e5-bc1e-391045bb0a87" />
